### PR TITLE
the main page allow users to move books between shelves

### DIFF
--- a/src/components/BookDashboard.js
+++ b/src/components/BookDashboard.js
@@ -23,7 +23,7 @@ const BookDashboard = (props) => {
       setBookWillRead(wantToRead);
       setRead(read);
     });
-  }, []);
+  }, [props.bookCategories]);
 
   const onShowReadStatus = (book) => {
     allBooks.forEach(item => {
@@ -34,29 +34,34 @@ const BookDashboard = (props) => {
     setBooks(books);
   };
 
-  const handleAfterGetValueFromReadStatus = (item) => {
-    allBooks.forEach(book => {
-      book.isShowReadStatus = false;
-      book.isShowRoundStatus = true;
+  const onChangeAfterUpdateShelf = (book, shelf) => {
+    allBooks.forEach(item => {
+      item.isShowReadStatus = false;
+      item.isShowRoundStatus = true;
+      if (book.title === item.title) {
+        book.shelf = shelf;
+      }
     });
     const books = [...allBooks];
+
+    //After setBooks, I expected book will change the shelf
     setBooks(books);
-    // console.log(item)
-  };
+  }
+
   return (
     <div>
       <header className="header">Book Shelf</header>
       <div className="currently-reading-container">
         <h2>{props.bookCategories.currentlyTitle}</h2>
-        <BookList books={currentlyBook} onShowReadStatus={onShowReadStatus} handleAfterGetValueFromReadStatus={handleAfterGetValueFromReadStatus}/>
+        <BookList books={currentlyBook} onShowReadStatus={onShowReadStatus} handleAfterUpdateShelf={onChangeAfterUpdateShelf}/>
       </div>
       <div className="want-to-read-container">
         <h2>{props.bookCategories.wantToReadTitle}</h2>
-        <BookList books={wantToRead} onShowReadStatus={onShowReadStatus} handleAfterGetValueFromReadStatus={handleAfterGetValueFromReadStatus}/>
+        <BookList books={wantToRead} onShowReadStatus={onShowReadStatus} handleAfterUpdateShelf={onChangeAfterUpdateShelf}/>
       </div>
       <div className="completed-read-container">
         <h2>{props.bookCategories.readTitle}</h2>
-        <BookList books={read} onShowReadStatus={onShowReadStatus} handleAfterGetValueFromReadStatus={handleAfterGetValueFromReadStatus}/>
+        <BookList books={read} onShowReadStatus={onShowReadStatus} handleAfterUpdateShelf={onChangeAfterUpdateShelf}/>
       </div>
     </div>
   );

--- a/src/components/BookList.js
+++ b/src/components/BookList.js
@@ -5,9 +5,10 @@ const BookList = (props) => {
     props.onShowReadStatus(book);
   };
 
-  const onChooseReadStatus = (item) => {
-    props.handleAfterGetValueFromReadStatus(item);
-  }
+  const onAfterUpdateShelf = (book, shelf) => {
+    props.handleAfterUpdateShelf(book, shelf);
+  };
+
   return (
     <div className="list-books-container">
       {props.books.map((book) => {
@@ -28,7 +29,7 @@ const BookList = (props) => {
               <div className="title-book">{book.title}</div>
             </div>
             <div className="read-status">
-              {book.isShowReadStatus && <ReadStatus onChooseReadStatus={onChooseReadStatus}/>}
+              {book.isShowReadStatus && <ReadStatus book={book} onAfterUpdateShelf={onAfterUpdateShelf}/>}
             </div>
           </div>
         );

--- a/src/components/ReadStatus.js
+++ b/src/components/ReadStatus.js
@@ -1,24 +1,40 @@
+import { update } from "../BooksAPI";
 import "./../utils/read-status.css";
 import { useState } from 'react';
 
-const ReadStatus = (props) => {
+const ReadStatus = ({book, onAfterUpdateShelf}) => {
   const [status, setStatus] = useState({
-    "Currently Reading": false,
-    "Want To Read": false,
-    "Read": false,
-    "None": true,
+    "Currently Reading": book.shelf === 'currentlyReading',
+    "Want To Read": book.shelf === 'wantToRead',
+    "Read": book.shelf === 'read',
+    "None": book.shelf === '',
   });
 
   const onClickReadStatus = (item) => {
+    const convertShelf = {
+      'currentlyReading' : 'Currently Reading',
+      'wantToRead': 'Want To Read',
+      'read': 'Read',
+      'none': 'None',
 
-    //Chose proper, item of status can not change value
-    let statusObj = {};
+    }
 
-    Object.keys(status).map(key => {
-      // `${key}` = key === item,
-    });
-    console.log(status)
-    props.onChooseReadStatus(item);
+    Object.keys(convertShelf).forEach(shelf => {
+      if ([convertShelf[shelf]][0] === item) {
+        update(book, shelf);
+        onAfterUpdateShelf(book, shelf);
+      }
+    })
+
+    const currentStatus = {
+      ...status,
+      "Currently Reading": item === "Currently Reading",
+      "Want To Read": item === "Want To Read",
+      "Read": item === "Read",
+      "None": item === "None",
+    };
+    
+    setStatus(currentStatus);
   }
 
   return (
@@ -37,7 +53,7 @@ const ReadStatus = (props) => {
                 }`}
                 onClick={() => onClickReadStatus(item)}
               >
-                {status[`${item}`] ? <>&#x2713;</> : ""} {item}
+                {status[`${item}`] ? <>&#x2713;</> : ""} <span className="status-item">{item}</span>
               </li>
             );
           })}

--- a/src/utils/read-status.css
+++ b/src/utils/read-status.css
@@ -32,3 +32,7 @@
 .is-active-status-item {
   background-color: aqua !important;
 }
+
+.status-item {
+  padding-left: 20px;
+}


### PR DESCRIPTION
The main page shows a control that allows users to move books between shelves. The control should be tied to each book instance. The functionality of moving a book to a different shelf works correctly.